### PR TITLE
Fix #11: script name show wrong

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { initI18n, t } from './i18n'
 ;(async () => {
   await initI18n()
   yargs
+    .scriptName('intlify')
     .usage(t('Usage: $0 <command> [options]'))
     .commandDir('./commands')
     .demandCommand()


### PR DESCRIPTION
This PR is a fix for #11 which is caused by `yargs`. See also [yargs PR #1143](https://github.com/yargs/yargs/pull/1143).