### PR TITLE
fix: move source-map to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "debug": "^4.3.1",
     "glob": "^7.1.6",
     "jsonc-eslint-parser": "^0.6.0",
+    "source-map": "^0.6.1",
     "yaml-eslint-parser": "^0.2.0",
     "yargs": "^16.2.0"
   },
@@ -61,7 +62,6 @@
     "opener": "^1.5.1",
     "prettier": "^2.2.0",
     "shipjs": "^0.23.0",
-    "source-map": "^0.6.1",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3",
     "typescript-eslint-language-service": "^4.1.2"


### PR DESCRIPTION
I'm using `@intlify/vite-plugin-vue-i18n` with yarn 2.

When starting vite I get:

```
Error: @intlify/cli tried to access source-map, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: source-map (via "source-map")
Required by: @intlify/cli@npm:0.2.0 (via ./.yarn/cache/@intlify-cli-npm-0.2.0-11f1d4a30e-f709484da4.zip/node_modules/@intlify/cli/lib/src/generator/)
```

My workaround for now is adding the following to `.yarnrc.yml`

```yml
packageExtensions:
  "@intlify/cli@0.2.0":
    dependencies:
      source-map: "*"
```

It would certainly be nice if that wouldn't be necessary :wink:
Hence this PR.